### PR TITLE
Make Honey Pot usages data driven

### DIFF
--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
@@ -31,6 +31,7 @@ import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
+import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -39,6 +40,11 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
 @EventBusSubscriber(modid = BuzzierBees.MOD_ID)
 public class BBEvents {
+	
+	@SubscribeEvent
+	public static void addHoneyPotReloadListener(AddReloadListenerEvent event) {
+		event.addListener(HoneyPotManager.getInstance());
+	}
 
 	@SubscribeEvent
 	public static void onLivingSpawned(EntityJoinWorldEvent event) {

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/HoneyPotManager.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/HoneyPotManager.java
@@ -1,0 +1,133 @@
+package com.minecraftabnormals.buzzier_bees.core.other;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.Nullable;
+
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import com.minecraftabnormals.buzzier_bees.common.blocks.HoneyPotBlock;
+import com.minecraftabnormals.buzzier_bees.core.BuzzierBees;
+import com.mojang.datafixers.util.Pair;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.resources.JsonReloadListener;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.profiler.IProfiler;
+import net.minecraft.resources.IResourceManager;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.crafting.CraftingHelper;
+
+/***
+ * This class is responsible for listening to changes in the Honey Pot json
+ * files and generating Honey Pot usages based on that. It is registered as a
+ * json listener in { {@link BBEvents#addHoneyPotReloadListener()}.
+ *
+ */
+public class HoneyPotManager extends JsonReloadListener {
+
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+	private static final String FOLDER = BuzzierBees.MOD_ID + "-honey_pot";
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	private static HoneyPotManager instance;
+
+	private Map<ResourceLocation, HoneyPotUsage> usages;
+
+	public HoneyPotManager() {
+		super(GSON, FOLDER);
+
+		usages = new HashMap<>();
+	}
+
+	@Override
+	protected void apply(Map<ResourceLocation, JsonElement> objectIn, IResourceManager resourceManagerIn,
+			IProfiler profilerIn) {
+
+		for (Entry<ResourceLocation, JsonElement> entry : objectIn.entrySet()) {
+			ResourceLocation rl = entry.getKey();
+			JsonElement elem = entry.getValue();
+			try {
+				if (elem.isJsonObject())
+					usages.put(rl, deserialize(JSONUtils.getJsonObject(elem, "top element")));
+			} catch (JsonParseException e) {
+				LOGGER.error("Parsing error loading honey pot usage {}", rl, e);
+			}
+		}
+
+	}
+
+	/***
+	 * Get the output for the honey pot.
+	 * 
+	 * @param stack    The input.
+	 * @param honeypot The block state of the clicked honey pot.
+	 * @param rand     A RNG.
+	 * @return A pair with the output item stack and the updated honey level for the
+	 *         honey pot, or null if the input is invalid or the updated honey level
+	 *         would be illegal.
+	 */
+	@Nullable
+	public Pair<ItemStack, Integer> get(ItemStack stack, BlockState honeypot, Random rand) {
+		for (HoneyPotUsage usage : usages.values())
+			if (usage.input.test(stack)) {
+				int level = honeypot.get(HoneyPotBlock.HONEY_LEVEL);
+				int updatedLevel = level + usage.level;
+				if (HoneyPotBlock.HONEY_LEVEL.getAllowedValues().contains(updatedLevel))
+					return Pair.of(usage.output.copy(), rand.nextFloat() <= usage.chance ? updatedLevel : level);
+				else
+					return null;
+			}
+		return null;
+	}
+
+	/***
+	 * See {@link HoneyPotManager#get()}.
+	 */
+	@Nullable
+	public static Pair<ItemStack, Integer> getUsage(ItemStack stack, BlockState honeypot, Random rand) {
+		return getInstance().get(stack, honeypot, rand);
+	}
+
+	/***
+	 * Get the singleton HoneyPotManager object.
+	 */
+	public static HoneyPotManager getInstance() {
+		if (instance == null)
+			instance = new HoneyPotManager();
+		return instance;
+	}
+
+	private static HoneyPotUsage deserialize(JsonObject json) {
+		HoneyPotUsage usage = new HoneyPotUsage();
+		usage.input = Ingredient.deserialize(JSONUtils.getJsonObject(json, "input"));
+		usage.output = CraftingHelper.getItemStack(JSONUtils.getJsonObject(json, "output"), true);
+		usage.level = JSONUtils.getInt(json, "level");
+		if (usage.level < -4 || usage.level > 4)
+			throw new JsonSyntaxException("Member level does not meet requirement -4 < level < 4");
+		usage.chance = JSONUtils.getFloat(json, "chance");
+
+		return usage;
+	}
+
+	private static class HoneyPotUsage {
+		private Ingredient input;
+		private ItemStack output;
+		private int level;
+		private float chance;
+	}
+
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/air.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/air.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:air"
+  },
+  "output": {
+    "item": "minecraft:honey_block"
+  },
+  "level": -4,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/apple.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/apple.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:apple"
+  },
+  "output": {
+    "item": "buzzier_bees:honey_apple"
+  },
+  "level": -1,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/bread.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/bread.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:bread"
+  },
+  "output": {
+    "item": "buzzier_bees:honey_bread"
+  },
+  "level": -1,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/cooked_porkchop.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/cooked_porkchop.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:cooked_porkchop"
+  },
+  "output": {
+    "item": "buzzier_bees:glazed_porkchop"
+  },
+  "level": -1,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/glass_bottle.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/glass_bottle.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:glass_bottle"
+  },
+  "output": {
+    "item": "minecraft:honey_bottle"
+  },
+  "level": -1,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honey_block.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honey_block.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:honey_block"
+  },
+  "output": {
+    "item": "minecraft:air"
+  },
+  "level": 4,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honey_bottle.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honey_bottle.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:honey_bottle"
+  },
+  "output": {
+    "item": "minecraft:glass_bottle"
+  },
+  "level": 1,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honey_wand.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honey_wand.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "buzzier_bees:honey_wand"
+  },
+  "output": {
+    "item": "buzzier_bees:sticky_honey_wand"
+  },
+  "level": -1,
+  "chance": 1
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honeycomb.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/honeycomb.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "minecraft:honeycomb"
+  },
+  "output": {
+    "item": "minecraft:air"
+  },
+  "level": 1,
+  "chance": 0.33
+}

--- a/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/sticky_honey_wand.json
+++ b/src/main/resources/data/buzzier_bees/buzzier_bees-honey_pot/sticky_honey_wand.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "item": "buzzier_bees:sticky_honey_wand"
+  },
+  "output": {
+    "item": "buzzier_bees:honey_wand"
+  },
+  "level": 1,
+  "chance": 1
+}


### PR DESCRIPTION
This pull request makes the honey pot usages data driven, as suggested by #139. This is done by adding the class HoneyPotManager, which is a JsonReloadListener that reads json files that defines how the honey pot can be used.